### PR TITLE
Fixed Exit Problem from 1.0.1

### DIFF
--- a/src/GUI_handler.py
+++ b/src/GUI_handler.py
@@ -50,7 +50,7 @@ def init() -> (tk.Tk, tk.Canvas):
                                        .start_stream(video=True, video_canvas=video_canvas))
     stop_btn: ttk.Button = ttk.Button(control_frame, text="Stop", command=player_handler.stop_stream)
     mute_btn: ttk.Button = ttk.Button(control_frame, text="Mute/Unmute", command=player_handler.toggle_mute)
-    # exit_btn: ttk.Button = ttk.Button(control_frame, text="Exit", command=player_handler.exit_program(root))
+    exit_btn: ttk.Button = ttk.Button(control_frame, text="Exit", command=player_handler.exit_program)
 
     volume_label: ttk.Label = ttk.Label(control_frame, text="Volume")
     volume_slider: ttk.Scale = ttk.Scale(control_frame, from_=0, to=100, orient="horizontal",
@@ -62,7 +62,7 @@ def init() -> (tk.Tk, tk.Canvas):
     video_btn.grid(row=0, column=1, padx=5)
     stop_btn.grid(row=0, column=2, padx=5)
     mute_btn.grid(row=0, column=3, padx=5)
-    # exit_btn.grid(row=0, column=4, padx=5)
+    exit_btn.grid(row=0, column=4, padx=5)
     volume_label.grid(row=1, column=0, padx=5)
     volume_slider.grid(row=1, column=1, columnspan=4, sticky="ew")
 

--- a/src/init.py
+++ b/src/init.py
@@ -1,8 +1,20 @@
+import sys
+
 from typing import Tuple
 from src import GUI_handler
 
+try:
+    # The following comments stop PyCharm from complaining
+    # noinspection PyUnresolvedReferences
+    import tkinter as tk
+    # noinspection PyUnresolvedReferences
+    from tkinter import ttk
+except ImportError:
+    print("Make sure you have tk installed\n")
+    sys.exit(0)
 
-def init() -> Tuple:
+
+def init() -> Tuple[tk.Tk, tk.Canvas]:
     """
     Initializes the program, to make sure everything is imported correctly
     :return: The root Tk instance and the video canvas.

--- a/src/player_handler.py
+++ b/src/player_handler.py
@@ -69,7 +69,8 @@ def set_volume(value: str) -> None:
     config_handler.save_settings(volume=volume)
 
 
-def exit_program(root: tk.Tk) -> None:
+def exit_program() -> None:
     """Stops playback and exits the application."""
     stop_stream()
-    root.destroy()
+    print("Quit SwarmFM")
+    sys.exit(0)

--- a/swarmFM.py
+++ b/swarmFM.py
@@ -1,4 +1,16 @@
+import sys
+
 from src import init
+
+try:
+    # The following comments stop PyCharm from complaining
+    # noinspection PyUnresolvedReferences
+    import tkinter as tk
+    # noinspection PyUnresolvedReferences
+    from tkinter import ttk
+except ImportError:
+    print("Make sure you have tk installed\n")
+    sys.exit(0)
 
 # YouTube Live URL
 yt_url: str = "https://www.youtube.com/@boop/live"


### PR DESCRIPTION
I fixed the Exit Button Problem from Version 1.0.1 and added

The important change was to exchange `root.destroy()` in `player_handler.py` with `sys.exit(0)`.